### PR TITLE
seek: fix spelling (index <-> _index)

### DIFF
--- a/src/lib/byte-buffer.js
+++ b/src/lib/byte-buffer.js
@@ -166,7 +166,7 @@ class ByteBuffer {
   // Seeks given number of bytes
   // Note: Backwards seeking is supported
   seek(bytes = 1) {
-    this.index += bytes;
+    this._index += bytes;
     return this;
   }
 


### PR DESCRIPTION
Tiny error.